### PR TITLE
Fix getSubMenu subscription type

### DIFF
--- a/src/app/services/data.service.ts
+++ b/src/app/services/data.service.ts
@@ -211,7 +211,7 @@ export class DataService {
     let lista = []
 
     // this.http.get("/assets/data/submenu.json").subscribe((res: any[]) => {
-    this.http.get("/assets/data/submenu.json").subscribe((res: []) => {
+    this.http.get<any[]>("/assets/data/submenu.json").subscribe((res: any[]) => {
 
       //res.filter
       lista = res.filter((obj) => {


### PR DESCRIPTION
## Summary
- fix subscription callback typing in `getSubMenu`

## Testing
- `npm run tsc` *(fails: Cannot find module '@angular/...')*

------
https://chatgpt.com/codex/tasks/task_e_68558790d1348322b7a62e5e386df98f