### PR TITLE
Add basic Express backend

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,4 @@ npm-debug.log*
 .firebase
 *-debug.log
 .runtimeconfig.json
+backend/node_modules

--- a/backend/README.md
+++ b/backend/README.md
@@ -1,0 +1,20 @@
+# Backend API
+
+Este backend está construido con **Express** y utiliza **SQLite** como base de datos. Provee un servicio básico para registrar los mismos campos que utiliza el proyecto frontend de aspirantes.
+
+## Comandos
+
+```bash
+cd backend
+npm install    # instalar dependencias
+npm start      # inicia el servidor en el puerto 3000
+```
+
+La primera vez que se ejecuta `npm start` se crea el archivo `database.sqlite` con las tablas:
+
+- `aspirantes`
+- `aspirante_soci`
+- `empleados`
+- `users`
+
+Cada tabla contiene todos los campos definidos en las interfaces del frontend.

--- a/backend/db.js
+++ b/backend/db.js
@@ -1,0 +1,121 @@
+const sqlite3 = require('sqlite3').verbose();
+const path = require('path');
+
+const dbPath = path.join(__dirname, 'database.sqlite');
+const db = new sqlite3.Database(dbPath);
+
+function init() {
+  db.serialize(() => {
+    db.run(`CREATE TABLE IF NOT EXISTS aspirantes (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      asp_id TEXT,
+      asp_cedula TEXT,
+      asp_codigo TEXT,
+      asp_nombres TEXT,
+      asp_apellidop TEXT,
+      asp_apellidom TEXT,
+      asp_pais TEXT,
+      asp_sexo TEXT,
+      asp_edad TEXT,
+      asp_correo TEXT,
+      asp_ecivil TEXT,
+      asp_gpo_sanguineo TEXT,
+      asp_cargo TEXT,
+      asp_cargo_area TEXT,
+      asp_sueldo TEXT,
+      asp_conadis TEXT,
+      asp_nro_conadis TEXT,
+      asp_discapacidad TEXT,
+      asp_porcentaje TEXT,
+      asp_sustituto TEXT,
+      asp_sustituto_cedula TEXT,
+      asp_sustituto_nombre TEXT,
+      asp_sustituto_parentesco TEXT,
+      asp_experiencia TEXT,
+      asp_nmb_experiencia TEXT,
+      asp_ing_entrevista TEXT,
+      asp_fch_ingreso TEXT,
+      asp_telefono TEXT,
+      asp_direccion TEXT,
+      asp_hora_entrevista TEXT,
+      asp_referencia TEXT,
+      asp_jefe_area TEXT,
+      asp_estado INTEGER,
+      asp_observaciones TEXT,
+      asp_titulo_nombre TEXT,
+      asp_observacion_final TEXT,
+      asp_academico TEXT,
+      asp_fecha_nacimiento TEXT,
+      asp_militar TEXT,
+      asp_aprobacion INTEGER,
+      asp_evaluacion TEXT,
+      asp_condicion TEXT,
+      asp_lugar_nacimiento TEXT,
+      asp_etnia TEXT,
+      asp_religion TEXT,
+      asp_recomendado TEXT,
+      asp_url_foto TEXT,
+      atv_aspirante TEXT,
+      atv_fingreso TEXT,
+      atv_fverificado INTEGER,
+      atv_plegales INTEGER,
+      atv_pfiscalia INTEGER,
+      atv_ppenales INTEGER,
+      atv_plaborales INTEGER,
+      atv_verificado INTEGER,
+      atv_observacion TEXT,
+      usuario TEXT
+    );`);
+
+    db.run(`CREATE TABLE IF NOT EXISTS aspirante_soci (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      aov_id TEXT,
+      aov_aspirante TEXT,
+      aov_iess_clave TEXT,
+      aov_banco_nombre TEXT,
+      aov_banco_cuenta TEXT,
+      aov_serv_agua TEXT,
+      aov_serv_electico TEXT,
+      aov_serv_alcantarilla TEXT,
+      aov_serv_transporte TEXT,
+      aov_ingresos REAL,
+      aov_ingresos_otros REAL,
+      aov_gastos REAL,
+      aov_vivienda TEXT,
+      aov_construccion TEXT,
+      aov_descripcion_vivienda TEXT,
+      aov_familiares TEXT,
+      aov_familiar TEXT,
+      aov_responsable TEXT,
+      aov_contacto_causa TEXT
+    );`);
+
+    db.run(`CREATE TABLE IF NOT EXISTS empleados (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      emp_nombres TEXT,
+      emp_apellidos TEXT,
+      emp_cedula TEXT,
+      emp_codigo TEXT,
+      emp_nacion TEXT,
+      emp_sexo TEXT,
+      emp_edad TEXT,
+      emp_civil TEXT,
+      emp_departamento TEXT
+    );`);
+
+    db.run(`CREATE TABLE IF NOT EXISTS users (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      uid TEXT,
+      email TEXT,
+      session TEXT,
+      lastlogin TEXT,
+      displayname TEXT,
+      role TEXT,
+      iplogin TEXT,
+      photo TEXT,
+      password TEXT
+    );`);
+  });
+}
+
+module.exports = { db, init };

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "backend",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "start": "node server.js"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs",
+  "dependencies": {
+    "express": "^5.1.0",
+    "sqlite3": "^5.1.7"
+  }
+}

--- a/backend/server.js
+++ b/backend/server.js
@@ -1,0 +1,57 @@
+const express = require('express');
+const { db, init } = require('./db');
+
+init();
+
+const app = express();
+app.use(express.json());
+const PORT = process.env.PORT || 3000;
+
+// Basic CRUD for aspirantes
+app.get('/aspirantes', (req, res) => {
+  db.all('SELECT * FROM aspirantes', [], (err, rows) => {
+    if (err) return res.status(500).json({error: err.message});
+    res.json(rows);
+  });
+});
+
+app.post('/aspirantes', (req, res) => {
+  const data = req.body;
+  const cols = Object.keys(data).join(',');
+  const placeholders = Object.keys(data).map(() => '?').join(',');
+  const values = Object.values(data);
+  db.run(`INSERT INTO aspirantes (${cols}) VALUES (${placeholders})`, values, function(err){
+    if (err) return res.status(500).json({error: err.message});
+    res.json({id: this.lastID});
+  });
+});
+
+app.get('/aspirantes/:id', (req, res) => {
+  db.get('SELECT * FROM aspirantes WHERE id=?', [req.params.id], (err, row) => {
+    if (err) return res.status(500).json({error: err.message});
+    if (!row) return res.status(404).json({error: 'Not found'});
+    res.json(row);
+  });
+});
+
+app.put('/aspirantes/:id', (req, res) => {
+  const data = req.body;
+  const assignments = Object.keys(data).map(k => `${k}=?`).join(',');
+  const values = Object.values(data);
+  values.push(req.params.id);
+  db.run(`UPDATE aspirantes SET ${assignments} WHERE id=?`, values, function(err){
+    if (err) return res.status(500).json({error: err.message});
+    res.json({changes: this.changes});
+  });
+});
+
+app.delete('/aspirantes/:id', (req, res) => {
+  db.run('DELETE FROM aspirantes WHERE id=?', [req.params.id], function(err){
+    if (err) return res.status(500).json({error: err.message});
+    res.json({changes: this.changes});
+  });
+});
+
+app.listen(PORT, () => {
+  console.log(`Server running on port ${PORT}`);
+});


### PR DESCRIPTION
## Summary
- add backend API folder using Express and SQLite
- store aspirantes/empleados/users info in SQLite database
- document how to run the backend
- ignore backend node_modules

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_6855957b17e48322a6843f75554f7864